### PR TITLE
Overwritable stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Registers a new cache by name.
 ###### Options
 
 * `name` The name of the cache.
+* `store` Allows overwriting the default store of the Kakku instance on a per-cache basis.
+* `collapseGets` Allows overwriting the default get mode of the Kakku instance on a per-cache basis.
+* `collapseFetches` Allows overwriting the default fetch mode of the Kakku instance on a per-cache basis.
+* `useAfterStale` Allows overwriting the default stale cache behavior of the Kakku instance on a per-cache basis.
 * `implementation` The method to call to calculate the value of the cache. Is given the cache parameters and should return a promise of an object with the following keys:
   - `data` The result of the calculation.
   - `ttl` The [TTL](http://en.wikipedia.org/wiki/Time_to_live) of the result, in milliseconds.
@@ -131,7 +135,7 @@ The events have the following properties:
 * `cacheName` The name of the cache.
 * `cacheKey` The key used for the operation.
 * `cacheParameters` The parameters used for the operation.
-* `time` The time the operation took. In high-resolution time. Not availabled on the `{{operation name}}_started` 
+* `time` The time the operation took. In high-resolution time. Not availabled on the `{{operation name}}_started`
 
 #####
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,22 @@ class Kakku extends EventEmitter {
         this.caches = new Map();
     }
 
-    register ({ name, implementation, useAfterStale, collapseFetches, collapseGets }) {
+    register ({
+        name,
+        implementation,
+        useAfterStale,
+        collapseFetches,
+        collapseGets,
+        store,
+    }) {
         const cache = new Cache({
             prefix: this.prefix,
-            store: this.store,
             name: name,
             implementation: implementation,
             useAfterStale: defaultValue(useAfterStale).to(this.useAfterStale),
             collapseFetches: defaultValue(collapseFetches).to(this.collapseFetches),
             collapseGets: defaultValue(collapseGets).to(this.collapseGets),
+            store: defaultValue(store).to(this.store),
             onEvent: (eventName, event) => { this.emit(eventName, event); },
         });
 

--- a/test/spec/KakkuSpec.js
+++ b/test/spec/KakkuSpec.js
@@ -11,6 +11,7 @@ describe("Kakku", function () {
     const DEFAULT_VALUE = { meow: "dog" };
     const MOCK_STORE_NAME = "MockStore";
     var mockStore;
+    var secondaryMockStore;
     var implementation;
     var kakku;
     var result;
@@ -617,5 +618,31 @@ describe("Kakku", function () {
         itShouldEmitMiss();
         itShouldNotEmit("hit");
         itShouldNotEmit("error");
+    });
+
+    describe("when the cache overrides the default store", function () {
+        setupStore();
+        setupKakku();
+
+        beforeEach(function () {
+            implementation = sinon.spy(defaultImplementation);
+            secondaryMockStore = new MockStore(createEmptyData());
+            kakku.register({
+                name: DEFAULT_CACHE_NAME,
+                implementation: implementation,
+                store: secondaryMockStore,
+            });
+        });
+
+        fetchDefaultFromCache();
+        wait();
+
+        it("should not use the default store", function () {
+            mockStore.get.should.not.have.been.called;
+        });
+
+        it("should use the secondary store", function () {
+            secondaryMockStore.get.should.have.been.calledOnce;
+        });
     });
 });


### PR DESCRIPTION
Allows overriding the default store on a per-cache basis, e.g.

``` javascript
kakku.register({
  name: "myCache",
  implementation: function () {...},
  store: new RedisStore(...),
});
```
